### PR TITLE
Zopfli 1.0.1

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -16,7 +16,7 @@ bin.run(['--help'], err => {
 		}
 
 		const builder = new BinBuild()
-			.src('https://github.com/google/zopfli/archive/6818a0859063b946094fb6f94732836404a0d89a.zip')
+			.src('https://github.com/google/zopfli/archive/zopfli-1.0.1.zip')
 			.cmd(`mkdir -p ${bin.dest()}`)
 			.cmd(`${makeBin} zopflipng && mv ./zopflipng ${bin.path()}`);
 

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,7 @@ test.cb('rebuild the zopflipng binaries', t => {
 	const tmp = tempy.directory();
 
 	new BinBuild()
-		.src('https://github.com/google/zopfli/archive/a29e46ba9f268ab273903558dcb7ac13b9fe8e29.zip')
+		.src('https://github.com/google/zopfli/archive/zopfli-1.0.1.zip')
 		.cmd(`mkdir -p ${tmp}`)
 		.cmd(`make zopflipng && mv ./zopflipng ${path.join(tmp, 'zopflipng')}`)
 		.run(err => {


### PR DESCRIPTION
- [x] Use latest release [`zopfli-1.0.1`](https://github.com/google/zopfli/releases/tag/zopfli-1.0.1)
- Update pre-compiled binaries.
    - [ ] Windows
    - [ ] Linux