### PR TITLE
Fix FreeBSD compiler selection

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -10,15 +10,17 @@ bin.run(['--help'], err => {
 		log.info('compiling from source');
 
 		let makeBin = 'make';
+		let makeArgs = '';
 
 		if (process.platform === 'freebsd') {
 			makeBin = 'gmake';
+			makeArgs = 'CC=cc CXX=c++';
 		}
 
 		const builder = new BinBuild()
 			.src('https://github.com/google/zopfli/archive/6818a0859063b946094fb6f94732836404a0d89a.zip')
 			.cmd(`mkdir -p ${bin.dest()}`)
-			.cmd(`${makeBin} zopflipng && mv ./zopflipng ${bin.path()}`);
+			.cmd(`${makeBin} zopflipng ${makeArgs} && mv ./zopflipng ${bin.path()}`);
 
 		return builder.run(err => {
 			if (err) {


### PR DESCRIPTION
Zopfli's makefile for some reason specifies CC=gcc CXX=g++, which is not what you usually want on FreeBSD.

On my machine, the g++-compiled zopflipng doesn't start:

    /usr/local/lib/compat/libstdc++.so.6: version GLIBCXX_3.4.20 required by zopflipng not found