### PR TITLE
Add vendor/source to published npm files

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "files": [
     "cli.js",
     "index.js",
-    "lib"
+    "lib",
+    "vendor/source"
   ],
   "keywords": [
     "imagemin",


### PR DESCRIPTION
When attempting to install on a client that builds from source (e.g., alpine), the install fails with: `✖ Error: ENOENT: no such file or directory`.

This is due to the tar file not being published to npm; therefore, it is not available to be used for the compile step.

This change simply adds the `vendor/source` directory to the files that will be published to npm.